### PR TITLE
Some controllers want to use Filters without an object

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -785,7 +785,9 @@ class AdminControllerCore extends Controller
         }
 
         $filters = $this->context->cookie->getFamily($prefix.$this->list_id.'Filter_');
-        $definition = ObjectModel::getDefinition($this->className);
+        if (isset($this->className) && $this->className) 
+        	$definition = ObjectModel::getDefinition($this->className);
+        
 
         foreach ($filters as $key => $value) {
             /* Extracting filters from $_POST on key filter_ */


### PR DESCRIPTION
Some modules may want to use Filters without an objectModel.
In that case $this->className is not set.